### PR TITLE
Fixing test failures

### DIFF
--- a/dispatches/models/nuclear_case/h2_ideal_vap.py
+++ b/dispatches/models/nuclear_case/h2_ideal_vap.py
@@ -57,13 +57,13 @@ configuration = {
                              'B': (-11.363417,  # [2]
                                    pyunits.J/pyunits.mol/pyunits.K/pyunits.kK),
                              'C': (11.432816,  # [2]
-                                   pyunits.J/pyunits.mol/pyunits.K/pyunits.kK**2),
+                                   pyunits.J/pyunits.mol/pyunits.K/pyunits.kiloK**2),
                              'D': (-2.772874,  # [2]
-                                   pyunits.J/pyunits.mol/pyunits.K/pyunits.kK**3),
+                                   pyunits.J/pyunits.mol/pyunits.K/pyunits.kiloK**3),
                              'E': (-0.158558,  # [2]
-                                   pyunits.J/pyunits.mol/pyunits.K*pyunits.kK**2),
+                                   pyunits.J/pyunits.mol/pyunits.K*pyunits.kiloK**2),
                              'F': (-9.980797,  # [2]
-                                   pyunits.J/pyunits.mol),
+                                   pyunits.kJ/pyunits.mol),
                              'G': (172.707974,  # [2]
                                    pyunits.J/pyunits.mol/pyunits.K),
                              'H': (0,  # [2]

--- a/dispatches/models/nuclear_case/test_h2_ideal_vap.py
+++ b/dispatches/models/nuclear_case/test_h2_ideal_vap.py
@@ -23,51 +23,53 @@ from idaes.core import FlowsheetBlock
 from idaes.generic_models.properties.core.generic.generic_property \
     import GenericParameterBlock
 
-m = ConcreteModel()
 
-m.fs = FlowsheetBlock(default={"dynamic": False})
+def test_h2_props():
+    m = ConcreteModel()
 
-m.fs.props = GenericParameterBlock(default=configuration)
+    m.fs = FlowsheetBlock(default={"dynamic": False})
 
-m.fs.state = m.fs.props.build_state_block(
-    m.fs.config.time, default={"defined_state": True})
+    m.fs.props = GenericParameterBlock(default=configuration)
 
-# Fix state
-m.fs.state[0].flow_mol.fix(1)
-m.fs.state[0].mole_frac_comp.fix(1)
-m.fs.state[0].temperature.fix(300)
-m.fs.state[0].pressure.fix(101325)
+    m.fs.state = m.fs.props.build_state_block(
+        m.fs.config.time, default={"defined_state": True})
 
-# Initialize state
-m.fs.state.initialize()
+    # Fix state
+    m.fs.state[0].flow_mol.fix(1)
+    m.fs.state[0].mole_frac_comp.fix(1)
+    m.fs.state[0].temperature.fix(300)
+    m.fs.state[0].pressure.fix(101325)
 
-# Verify against NIST tables
-assert value(m.fs.state[0].cp_mol) == pytest.approx(28.85, rel=1e-2)
-assert value(m.fs.state[0].enth_mol) == pytest.approx(43.4, rel=1e-2)
-assert value(m.fs.state[0].entr_mol) == pytest.approx(130.9, rel=1e-2)
-assert (value(m.fs.state[0].gibbs_mol/m.fs.state[0].temperature) ==
-        pytest.approx(-130.7, rel=1e-2))
+    # Initialize state
+    m.fs.state.initialize()
 
-# Try another temeprature
-m.fs.state[0].temperature.fix(500)
+    # Verify against NIST tables
+    assert value(m.fs.state[0].cp_mol) == pytest.approx(28.85, rel=1e-2)
+    assert value(m.fs.state[0].enth_mol) == pytest.approx(53.51, rel=1e-2)
+    assert value(m.fs.state[0].entr_mol) == pytest.approx(130.9, rel=1e-2)
+    assert (value(m.fs.state[0].gibbs_mol/m.fs.state[0].temperature) ==
+            pytest.approx(-130.7, rel=1e-2))
 
-solver = SolverFactory('ipopt')
-solver.solve(m.fs)
+    # Try another temeprature
+    m.fs.state[0].temperature.fix(500)
 
-assert value(m.fs.state[0].cp_mol) == pytest.approx(29.26, rel=1e-2)
-assert value(m.fs.state[0].enth_mol) == pytest.approx(5880, rel=1e-2)
-assert value(m.fs.state[0].entr_mol) == pytest.approx(145.7, rel=1e-2)
-assert (value(m.fs.state[0].gibbs_mol/m.fs.state[0].temperature) ==
-        pytest.approx(-134.0, rel=1e-2))
+    solver = SolverFactory('ipopt')
+    solver.solve(m.fs)
 
-# Try another temeprature
-m.fs.state[0].temperature.fix(900)
+    assert value(m.fs.state[0].cp_mol) == pytest.approx(29.26, rel=1e-2)
+    assert value(m.fs.state[0].enth_mol) == pytest.approx(5880, rel=1e-2)
+    assert value(m.fs.state[0].entr_mol) == pytest.approx(145.7, rel=1e-2)
+    assert (value(m.fs.state[0].gibbs_mol/m.fs.state[0].temperature) ==
+            pytest.approx(-134.0, rel=1e-2))
 
-solver = SolverFactory('ipopt')
-solver.solve(m.fs)
+    # Try another temeprature
+    m.fs.state[0].temperature.fix(900)
 
-assert value(m.fs.state[0].cp_mol) == pytest.approx(29.88, rel=1e-2)
-assert value(m.fs.state[0].enth_mol) == pytest.approx(17680, rel=1e-2)
-assert value(m.fs.state[0].entr_mol) == pytest.approx(163.1, rel=1e-2)
-assert (value(m.fs.state[0].gibbs_mol/m.fs.state[0].temperature) ==
-        pytest.approx(-143.4, rel=1e-2))
+    solver = SolverFactory('ipopt')
+    solver.solve(m.fs)
+
+    assert value(m.fs.state[0].cp_mol) == pytest.approx(29.88, rel=1e-2)
+    assert value(m.fs.state[0].enth_mol) == pytest.approx(17680, rel=1e-2)
+    assert value(m.fs.state[0].entr_mol) == pytest.approx(163.1, rel=1e-2)
+    assert (value(m.fs.state[0].gibbs_mol/m.fs.state[0].temperature) ==
+            pytest.approx(-143.4, rel=1e-2))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,3 @@
 # pytest.ini
 [pytest]
-# XXX: ignore broken tests, please remove this when fixed
-addopts =  --ignore=dispatches/models
 testpaths = dispatches


### PR DESCRIPTION
This PR fixes the test failures that were being seen in a number of PRs.

The issue was due to some bug fixes in IDAES relating to units in the NIST property methods - the H2 property package had been built to work and give the correct with the bugged version of IDAES, thus needed to be corrected once the bug was identified and fixed.