### PR TITLE
Get readthedocs working after opening the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 This is the primary repository for distributing dispatches software tools.
 
 ## Build Status
+[![Python package](https://github.com/gmlc-dispatches/dispatches/actions/workflows/python-package.yml/badge.svg)](https://github.com/gmlc-dispatches/dispatches/actions/workflows/python-package.yml)
 [![Documentation Status](https://readthedocs.org/projects/dispatches/badge/?version=latest)](https://dispatches.readthedocs.io/en/latest/?badge=latest)
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is the primary repository for distributing dispatches software tools.
 
 ## Build Status
-[![Documentation Status](https://readthedocs.com/projects/lbl-dispatches/badge/?version=latest&token=40e7de01965b54edaa56aa9e35f59008d2ac09b8c174bcf2b55b0f66c14f8d8b)](https://lbl-dispatches.readthedocs-hosted.com/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/dispatches/badge/?version=latest)](https://dispatches.readthedocs.io/en/latest/?badge=latest)
 
 ## Description
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,3 @@
 pytest-cov
+sphinx
+sphinx-rtd-theme


### PR DESCRIPTION
Now with the repo open we can use readthedocs.org and not readthedocs.com

Most of the work for this was done on the readthedocs.org site, not here in our code.

Also, sphinx was remove somewhere along the way, this brings it back into the `requirements-dev.txt` file.

Adding GitHub Actions badge here too.