### PR TITLE
fix RTD badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is the primary repository for distributing dispatches software tools.
 
 ## Build Status
 [![Python package](https://github.com/gmlc-dispatches/dispatches/actions/workflows/python-package.yml/badge.svg)](https://github.com/gmlc-dispatches/dispatches/actions/workflows/python-package.yml)
-[![Documentation Status](https://readthedocs.org/projects/dispatches/badge/?version=latest)](https://dispatches.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/dispatches/badge/?version=main)](https://dispatches.readthedocs.io/en/latest/?badge=main)
 
 ## Description
 


### PR DESCRIPTION
I got this wrong in PR #31, this should make the badge point to the correct "main" build of RTD.
