### PR TITLE
Fixing issue with solver

### DIFF
--- a/dispatches/models/fossil_case/thermal_oil/thermal_oil.py
+++ b/dispatches/models/fossil_case/thermal_oil/thermal_oil.py
@@ -100,7 +100,7 @@ class _StateBlock(StateBlock):
     def initialize(self, state_args={}, state_vars_fixed=False,
                    hold_state=False, outlvl=idaeslog.NOTSET,
                    temperature_bounds=(260, 616),
-                   solver='ipopt', optarg={'tol': 1e-8}):
+                   solver=None, optarg={'tol': 1e-8}):
         '''
         Initialization routine for property package.
 
@@ -165,7 +165,7 @@ class _StateBlock(StateBlock):
         else:
             sopt = optarg
 
-        opt = SolverFactory(solver)
+        opt=get_solver(solver, optarg)
 
         opt.options = sopt
 


### PR DESCRIPTION
The property package was throwing an error in the initialization step due to the solver being `None`. The module has been update to use the method `get_solver()` which solved the issue