### PR TITLE
adding pytest marker list and ignoring pytest logs in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ auto-save-list
 
 # MacOS
 .DS_Store
+
+# log
+*.log

--- a/dispatches/models/nuclear_case/unit_models/test_hydrogen_tank.py
+++ b/dispatches/models/nuclear_case/unit_models/test_hydrogen_tank.py
@@ -51,14 +51,14 @@ def test_config():
     # Create the ConcreteModel and the FlowSheetBlock
     m = ConcreteModel(name="H2TankModel")
     m.fs = FlowsheetBlock(default={"dynamic": False})
-    
+
     # Add hydrogen property parameter block
     m.fs.properties = GenericParameterBlock(default=configuration)
-    
+
     # Create an instance of the CHG tank
     m.fs.unit = HydrogenTank(default={"property_package": m.fs.properties,
                                       "dynamic": False})
-    
+
     # Check unit config arguments
     assert len(m.fs.unit.config) == 5
 
@@ -74,10 +74,10 @@ class TestH2IdealVap(object):
         # Create the ConcreteModel and the FlowSheetBlock
         m = ConcreteModel(name="H2TankModel")
         m.fs = FlowsheetBlock(default={"dynamic": False})
-        
+
         # Add hydrogen property parameter block
         m.fs.properties = GenericParameterBlock(default=configuration)
-        
+
         # Create an instance of the Hydrogen tank
         m.fs.unit = HydrogenTank(default={"property_package": m.fs.properties,
                                           "dynamic": False})
@@ -85,27 +85,27 @@ class TestH2IdealVap(object):
         # Fix tank geometry
         m.fs.unit.tank_diameter.fix(0.1)
         m.fs.unit.tank_length.fix(0.3)
-        
+
         # Fix initial state of tank
         m.fs.unit.previous_state[0].temperature.fix(300)
         m.fs.unit.previous_state[0].pressure.fix(1e5)
-        
+
         # Fix inlet state
         m.fs.unit.control_volume.properties_in[0].flow_mol.fix(100)
         m.fs.unit.control_volume.properties_in[0].mole_frac_comp.fix(1)
         m.fs.unit.control_volume.properties_in[0].temperature.fix(300)
         m.fs.unit.control_volume.properties_in[0].pressure.fix(1.10325e5)
-        
+
         # Fix Duration of Operation (Time Step)
         m.fs.unit.dt[0].fix(100)
-        
+
         # Fix the outlet flow to zero for tank filling type operation
         m.fs.unit.control_volume.properties_out[0].flow_mol.fix(0)
-        
+
         # Setting the bounds on the state variables
         m.fs.unit.control_volume.properties_in[0].pressure.setub(1e15)
         m.fs.unit.control_volume.properties_out[0].pressure.setub(1e15)
-        
+
         return m
 
     @pytest.mark.unit
@@ -122,12 +122,12 @@ class TestH2IdealVap(object):
         assert isinstance(hydrogentank.fs.unit.heat_duty, Var)
         assert isinstance(hydrogentank.fs.unit.previous_material_holdup, Var)
         assert isinstance(hydrogentank.fs.unit.previous_energy_holdup, Var)
-    
+
     # Check degrees of freedom
     @pytest.mark.unit
     def test_dof(self, hydrogentank):
         assert degrees_of_freedom(hydrogentank) == 0
-    
+
     # Check initialization
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -155,7 +155,7 @@ class TestH2IdealVap(object):
         assert (value(hydrogentank.fs.unit.control_volume.properties_out[0].\
                       dens_mol_phase["Vap"])
                 == pytest.approx(4244171.91, rel=1e-1))
-    
+
     # Try another inlet temperature
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -164,7 +164,7 @@ class TestH2IdealVap(object):
         results = solver.solve(hydrogentank)
         assert (results.solver.termination_condition ==
                 TerminationCondition.optimal)
-        
+
         assert (value(hydrogentank.fs.unit.control_volume.properties_out[0].pressure)
                 == pytest.approx(15536853611.796, rel=1e-1))
         assert (value(hydrogentank.fs.unit.control_volume.properties_out[0].temperature)
@@ -174,7 +174,6 @@ class TestH2IdealVap(object):
                 == pytest.approx(4244171.91, rel=1e-1))
 
     # Check report function
-    @pytest.mark.ui
     @pytest.mark.unit
     def test_report(self, hydrogentank):
         hydrogentank.fs.unit.report()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,10 @@
 # pytest.ini
 [pytest]
 testpaths = dispatches
+log_file = pytest.log
+log_file_date_format = %Y-%m-%dT%H:%M:%S
+log_file_format = %(asctime)s %(levelname)-7s <%(filename)s:%(lineno)d> %(message)s
+markers =
+    unit: quick tests that check the build and do not require a solver
+    component: quick tests that may require a solver
+    integration: tests that need a solver and take longer to run


### PR DESCRIPTION
- Added pytest markers to the `pytest.ini` file because noticed warnings that markers were missing
- Updated `.gitignore` to ignore log files generated
- Removed `ui` marker from one of the tests. For now, only 3 markers: `unit`, `component`, `integration`