### PR TITLE
Streamline installation procedure and GitHub Actions workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,6 +13,12 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+defaults:
+  run:
+    # important to make sure that all commands on Windows are run using Bash
+    # -l: login shell, needed when using Conda
+    shell: bash -l {0}
+
 jobs:
   tests:
     name: Tests (py${{ matrix.python-version }}/${{ matrix.os }})

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,22 +2,36 @@
 # with a variety of Python versions For more information see:
 # https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Checks
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - '*_rel'
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  tests:
+    name: Tests (py${{ matrix.python-version }}/${{ matrix.os }})
+    runs-on: ${{ matrix.os-version }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
-
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+        os:
+          - linux
+          - win64
+        include:
+          - os: linux
+            os-version: ubuntu-20.04
+          - os: win64
+            os-version: windows-2019
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,17 +24,21 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install Python package and dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        #
-        # Install idaes main branch (we test against main and not the release)
-        python -m pip install git+https://github.com/IDAES/idaes-pse.git@main
-        #
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        #
-        idaes get-extensions
+        _pip_install="pip install --progress-bar off"
+        echo '::group::Output of "pip install" commands'
+        $_pip_install --upgrade pip wheel setuptools
+        $_pip_install -r requirements-dev.txt
+        echo '::endgroup::'
+        echo '::group::Display installed packages'
+        conda list
+        pip list
+        pip show idaes-pse
+        echo '::endgroup::'
+        echo '::group::Output of "idaes get-extensions" command'
+        idaes get-extensions --verbose
+        echo '::endgroup::'
     - name: Lint with flake8
       if: false
       run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,3 +8,8 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
     fail_on_warning: true
+
+python:
+    version: "3.7"
+    install:
+        - requirements: requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -12,3 +12,48 @@ will be developed and used to identify and optimize Integrated Energy Systems fo
 power system via energy market signals.
 
 DISPATCHES is part of the DOE Grid Modernization Laboratory Consortium (GMLC).
+
+## Getting started
+
+### Using Conda environments
+
+The recommended way to install DISPATCHES is to use a Conda environment.
+
+A Conda environment is a separate installation directory where packages and even different Python versions can be installed
+without conflicting with other Python versions installed on the system, or other environments.
+
+To create a Conda environment, the `conda` command should be installed and configured for your operating system.
+Detailed steps to install and configure `conda` are available [here](https://conda.io/projects/conda/en/latest/user-guide/install/index.html).
+
+### For developers
+
+(Recommended) Create a dedicated Conda environment for development work:
+
+```sh
+conda create -n dispatches-dev python=3.8 pip --yes
+conda activate dispatches-dev
+```
+
+Clone the repository and enter the `dispatches` directory:
+
+```sh
+git clone https://github.com/gmlc-dispatches/dispatches
+cd dispatches
+```
+
+Install the Python package and all dependencies required for development work using pip and the `requirements-dev.txt` file:
+
+```sh
+pip install -r requirements-dev.txt
+```
+
+The developer installation will install the cloned directory in editable mode (as opposed to the default behavior of installing a copy of it),
+which means that any modification made to the code in the cloned directory
+(including switching to a different branch with `git switch`/`git checkout`, or updating the repository with the latest changes using `git pull`) will be available when using the package in Python,
+regardless of e.g. the current working directory.
+
+To test that the installation was successful, run the test suite using the `pytest` command:
+
+```sh
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 This is the primary repository for distributing dispatches software tools.
 
 ## Build Status
-[![Python package](https://github.com/gmlc-dispatches/dispatches/actions/workflows/python-package.yml/badge.svg)](https://github.com/gmlc-dispatches/dispatches/actions/workflows/python-package.yml)
+
+[![Python package](https://github.com/gmlc-dispatches/dispatches/actions/workflows/checks.yml/badge.svg)](https://github.com/gmlc-dispatches/dispatches/actions/workflows/checks.yml)
 [![Documentation Status](https://readthedocs.org/projects/dispatches/badge/?version=main)](https://dispatches.readthedocs.io/en/latest/?badge=main)
 
 ## Description

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -1,0 +1,5 @@
+Getting Started
+===============
+
+.. toctree::
+	install

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -65,7 +65,7 @@ For DISPATCHES developers
 
 If you plan to contribute to DISPATCHES's codebase, choose this option.
 
-.. note:: Typically, *contributing to DISPATCHES* will involve opening a Pull Request (PR) in DISPATCHES's repository. For more information, refer to :ref:`developer-guide`.
+.. note:: Typically, *contributing to DISPATCHES* will involve opening a Pull Request (PR) in DISPATCHES's repository.
 
 #. Create a Conda environment (in this example, named ``dispatches-dev``) where DISPATCHES and all dependendencies needed for development will be installed, then activate it:
 

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -1,0 +1,101 @@
+Installing DISPATCHES
+=====================
+
+Introduction
+------------
+
+.. _about-conda:
+
+Using Conda environments
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Conda environments are a way to create and manage multiple sets of packages and/or Python versions on the same system without incurring conflicts.
+Each Conda environment is a dedicated directory, separate from other Conda environments and the operating system's own directories, containing its own collection of packages, executables, and Python installation, including the Python interpreter.
+Once a Conda environment is *activated*, using the ``conda activate`` command in a terminal/console, the environment's own version of Python will be used to run commands or interactive sessions for the remainder of the session.
+
+For these reasons, Conda environments are especially useful to install and manage multiple projects (and/or multiple *versions* of the same project) on the same computer with minimal effort,
+as they provide a way to seamlessly switch between different projects without conflicts.
+
+Using Conda environments is not mandatory to be able to install and use DISPATCHES; however, it is strongly recommended.
+
+To use Conda environments, the ``conda`` package manager is required. Refer to the `Conda installation guide <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_ for detailed steps on how to install Conda for your operating system.
+
+General installation
+--------------------
+
+If you are going to use DISPATCHES's functionality, but *do not* plan to contribute code to DISPATCHES's codebase directly, choose this option.
+
+#. Create a Conda environment (in this example, named ``dispatches``) where DISPATCHES and its runtime dependencies will be installed:
+
+	.. code-block:: shell
+
+		conda create --name dispatches --yes python=3.8
+
+#. Activate the ``dispatches`` environment:
+
+	.. code-block:: shell
+
+		conda activate dispatches
+	
+	To verify that the correct environment is active, run the following command:
+
+	.. code-block:: shell
+
+		python -c "import sys; print(sys.executable)"
+	
+	If the environment was activated correctly, its name should be contained in the path displayed by the above command.
+
+	.. important:: The ``conda activate`` command described above must be run each time a new terminal/console session is started.
+
+#. Install DISPATCHES using ``pip``:
+
+	.. code-block:: shell
+
+		pip install https://github.com/gmlc-dispatches/dispatches/archive/main.zip
+
+#. To verify that the installation was successful, open a Python interpreter and try importing some of DISPATCHES's modules, e.g.:
+
+	.. code-block:: shell
+
+		python
+		>>> from dispatches.unit_models import *
+
+For DISPATCHES developers
+-------------------------
+
+If you plan to contribute to DISPATCHES's codebase, choose this option.
+
+.. note:: Typically, *contributing to DISPATCHES* will involve opening a Pull Request (PR) in DISPATCHES's repository. For more information, refer to :ref:`developer-guide`.
+
+#. Create a Conda environment (in this example, named ``dispatches-dev``) where DISPATCHES and all dependendencies needed for development will be installed, then activate it:
+
+	.. code-block:: shell
+
+		conda create --name dispatches-dev --yes python=3.8 && conda activate dispatches-dev
+
+	.. note:: For more information about using Conda environments, refer to the ":ref:`about-conda`" section above.
+
+#. Clone the DISPATCHES repository to your local development machine using ``git clone``, then enter the newly created ``dispatches`` subdirectory:
+
+	.. code-block:: shell
+
+		git clone https://github.com/gmlc-dispatches/dispatches && cd dispatches
+
+#. Install DISPATCHES and the development dependencies using ``pip`` and the ``requirements-dev.txt`` file:
+
+	.. code-block:: shell
+
+		pip install -r requirements-dev.txt
+
+#. To verify that the installation was successful, try running the DISPATCHES test suite using ``pytest``:
+
+	.. code-block:: shell
+
+		pytest
+
+
+
+
+
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,7 @@ Contents
 .. toctree::
    :maxdepth: 2
 
+   getting_started/index
    models/index
    license
    copyright

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 pytest-cov
 sphinx
 sphinx-rtd-theme
+
+--editable .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-pytest
-# we use jupyter notebooks
-jupyter
-# for visualizing DMF provenance
-graphviz
-# for IDAES DMF -dang 12/2020
-idaes-pse
-gridx-prescient
-nrel-pysam

--- a/setup.py
+++ b/setup.py
@@ -55,11 +55,24 @@ def read_requirements(input_file):
     return req
 
 
-with open("requirements.txt") as f:
-    package_list = read_requirements(f)
+class SpecialDependencies:
+    """
+    The following packages require special treatment, as they change rapidly between release cycles.
+    Two separate lists of dependencies are kept:
+    - for_release: to be used when cutting a release of DISPATCHES
+    - for_prerelease: to be used for the prerelease version of DISPATCHES (i.e. the `main` branch, and all PRs targeting it)
+    """
+    # idaes-pse: for IDAES DMF -dang 12/2020
+    for_release = [
+        "idaes-pse"
+    ]
+    for_prerelease = [
+        "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/main.zip",
+    ]
 
-with open("requirements-dev.txt") as f:
-    dev_package_list = read_requirements(f)
+
+SPECIAL_DEPENDENCIES = SpecialDependencies.for_prerelease
+
 
 ########################################################################################
 
@@ -100,7 +113,15 @@ setup(
     keywords="market simulation, chemical engineering, process modeling, hybrid power systems",
     packages=find_namespace_packages(),
     python_requires=">=3.6, <4",
-    install_requires=package_list,
+    install_requires=[
+        "pytest",
+        # we use jupyter notebooks
+        "jupyter",
+        # for visualizing DMF provenance
+        "graphviz",
+        "gridx-prescient",
+        "nrel-pysam",
+        *SPECIAL_DEPENDENCIES
+    ],
     package_data={"": ["*.json"]},  # Optional
-    extras_require={"dev": dev_package_list},
 )

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ class SpecialDependencies:
         "idaes-pse"
     ]
     for_prerelease = [
-        "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/main.zip",
+        "idaes-pse @ https://github.com/gmlc-dispatches/idaes-pse/archive/1.10.1.dispatches.2021.07.14.zip",
     ]
 
 


### PR DESCRIPTION
## Addresses issue: #47

## Summary/Motivation:

- Installation and dependency management should be streamlined so that the same steps can are used consistently by users and developers and in the CI (GitHub Actions) workflows
- This is done by implementing a "dual mode" (general + dev) scheme:
  - General installation mode:
    - Implies that the package is always installed without cloning the repo
    - Uses `pip install <target>`, where `<target>` is either a released version (from PyPI) or a prerelease version (from the `main` branch of this repository)
    - Dependencies are specified in `setup.py`
  - Dev installation mode:
    - Implies that the package is always installed by cloning the repo first
    - Uses `pip install -r requirements-dev.txt`
    - Extra dev dependencies are specified in `requirements-dev.txt`
  - "Special" dependencies (packages that change quickly within the release cycle) are treated consistently in both modes in `setup.py`

## Changes proposed in this PR:

- Implement "dual mode" installation strategy
  - Move base dependencies to `setup.py`
  - Remove `requirements.txt` as it is not needed according to this scheme
- Update GitHub Actions workflow
  - Use dev installation mode for `Tests` job
  - Add Windows support
- Add first pass at "Getting started" guide covering the dev installation mode

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md and COPYRIGHT.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
