### PR TITLE
remove time-index to battery constraints

### DIFF
--- a/dispatches/models/renewables_case/battery.py
+++ b/dispatches/models/renewables_case/battery.py
@@ -136,24 +136,24 @@ class BatteryStorageData(UnitModelBlockData):
         self.power_out = Port(noruleinit=True, doc="A port for electricity outflow")
         self.power_out.add(self.elec_out, "electricity")
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint()
         def state_evolution(b):
             return b.state_of_charge == b.initial_state_of_charge + (
                     b.charging_eta * b.dt * b.elec_in
                     - b.dt / b.discharging_eta * b.elec_out)
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint()
         def accumulate_energy_throughput(b):
             return b.energy_throughput == b.initial_energy_throughput + b.dt * (b.elec_in + b.elec_out) / 2
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint()
         def state_of_charge_bounds(b):
             return b.state_of_charge <= b.nameplate_energy - b.degradation_rate * b.energy_throughput
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint()
         def power_bound_in(b):
             return b.elec_in <= b.nameplate_power
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint()
         def power_bound_out(b):
             return b.elec_out <= b.nameplate_power


### PR DESCRIPTION
## Addresses issue:

Battery constraints are time independent and should not be time-indexed. Tests in test_battery.py pass with Pyomo==6.1.2

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md and COPYRIGHT.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
