### PR TITLE
Update idaes-pse prerelease requirement to 2.0.0a1.dispatches.2022.05.02 tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,11 @@ class SpecialDependencies:
     # idaes-pse: for IDAES DMF -dang 12/2020
     for_release = [
         # NOTE: this will fail until idaes-pse 2.0.0a1 is available on PyPI
+        # NOTE: the idaes-pse tag/release 2.0.0a1 does not contain the bug fixes implemented in IDAES/idaes-pse#827
         "idaes-pse==2.0.0a1",
     ]
     for_prerelease = [
-        "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/2.0.0a1.zip"
+        "idaes-pse @ https://github.com/gmlc-dispatches/idaes-pse/archive/2.0.0a1.dispatches.2022.05.02.zip"
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -64,10 +64,11 @@ class SpecialDependencies:
     """
     # idaes-pse: for IDAES DMF -dang 12/2020
     for_release = [
-        "idaes-pse=>1.11.0"
+        # NOTE: this will fail until idaes-pse 2.0.0a1 is available on PyPI
+        "idaes-pse==2.0.0a1",
     ]
     for_prerelease = [
-        "idaes-pse==1.13.0"
+        "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/2.0.0a1.zip"
     ]
 
 


### PR DESCRIPTION
## Summary/Motivation:
- Update the `idaes-pse` requirement to the 2.0.0a1 that contains the `idaes.apps.grid_integration` code introduced in IDAES/idaes-pse#787 needed by DISPATCHES

## Changes proposed in this PR:
- Update requirement for `idaes-pse` to 2.0.0a1 tag

## TODO
- [ ] `idaes-pse` 2.0.0a1 needs to be uploaded to PyPI before being able to create a new [dispatches](https://pypi.org/project/dispatches/) Python package distribution

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md and COPYRIGHT.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
