### PR TITLE
Update idaes-pse requirement to 2.0.0a2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,12 +64,11 @@ class SpecialDependencies:
     """
     # idaes-pse: for IDAES DMF -dang 12/2020
     for_release = [
-        # NOTE: this will fail until idaes-pse 2.0.0a1 is available on PyPI
-        # NOTE: the idaes-pse tag/release 2.0.0a1 does not contain the bug fixes implemented in IDAES/idaes-pse#827
-        "idaes-pse==2.0.0a1+220506",
+        # NOTE: this will fail until this idaes-pse version is available on PyPI
+        "idaes-pse==2.0.0a2",
     ]
     for_prerelease = [
-        "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/2.0.0a1+220506.zip"
+        "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/2.0.0a2.zip"
     ]
 
 


### PR DESCRIPTION
## Summary/Motivation:

- Assess compatibility problems when using latest IDAES release (May 2022, currently 2.0.0a2)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md and COPYRIGHT.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
