### PR TITLE
Update CI infrastructure for Jupyter notebooks to dispatches-nbcheck 0.2.x

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,0 +1,76 @@
+name: Install DISPATCHES
+description: Install DISPATCHES
+
+inputs:
+
+  conda-environment:
+    required: false
+    description: |
+      Name of the Conda environment to use for the installation. If empty (default), Conda will not be used and the system Python will be used instead
+    default: ''
+
+  python-version:
+    required: true
+    description: Python version to be installed in the environment
+
+  variant:
+    required: true
+    description: |
+      Which installation variant to use. Choices: "dev", "site"
+
+  repository:
+    required: false
+    description: Full name (i.e. user/repo) of the repository to install
+    default: gmlc-dispatches/dispatches
+
+  ref:
+    required: false
+    description: |
+      Git ref to install
+    default: main
+
+runs:
+  using: composite
+  steps:
+
+    - name: Setup Python in Conda env
+      if: inputs.conda-environment
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: ${{ inputs.conda-environment }}
+        python-version: ${{ inputs.python-version }}
+
+    - name: Setup Python (without Conda env)
+      if: '!inputs.conda-environment'
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install using pip (${{ inputs.variant }})
+      if: inputs.variant == 'dev'
+      shell: bash -l {0}
+      run: |
+        pip install -r requirements-dev.txt
+
+    - name: Install using pip (${{ inputs.variant }})
+      if: inputs.variant == 'site'
+      shell: bash -l {0}
+      env:
+        _pip_install_url: https://github.com/${{ inputs.repository }}@${{ inputs.ref }}
+      run: |
+        pip install "git+${_pip_install_url}"
+
+    - name: Install solver dependencies (IDAES extensions)
+      shell: bash -l {0}
+      run: |
+        echo "::group::Output of 'idaes get-extensions'"
+        idaes get-extensions --verbose
+        echo "::endgroup::"
+
+    - name: Show installed packages
+      shell: bash -l {0}
+      run: |
+        echo '::group::Display installed packages'
+        pip list
+        pip show pyomo idaes-pse dispatches
+        echo '::endgroup::'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ defaults:
     shell: bash -l {0}
 
 env:
-  PYTEST_ADDOPTS: "--color=yes -m 'not fails_in_ci'"
+  PYTEST_ADDOPTS: --color=yes -m 'not fails_in_ci'
 
 jobs:
 
@@ -63,7 +63,7 @@ jobs:
         idaes get-extensions --verbose
         echo '::endgroup::'
     - name: Lint with flake8
-      if: "false"
+      if: 'false'
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/notebooks-checks.yml
+++ b/.github/workflows/notebooks-checks.yml
@@ -17,6 +17,7 @@ defaults:
 
 env:
   DISPATCHES_TESTING_MODE: "true"
+  PYTEST_ADDOPTS: --color=yes -p no:python
 
 jobs:
 
@@ -24,12 +25,14 @@ jobs:
     name: Check .ipynb files in repo
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Run nbcheck (static)
-      uses: gmlc-dispatches/nbcheck@0.1.12
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/install  
       with:
-        setup-python: 'true'
-        type: static
+        variant: dev
+        python-version: '3.9'
+    - name: Run nbcheck (static)
+      run:
+        pytest --nbcheck=static
 
   nbcheck-execution:
     needs: [nbcheck-static]
@@ -48,29 +51,11 @@ jobs:
           - os: win64
             os-version: windows-2019
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/install  
       with:
+        variant: dev
         python-version: ${{ matrix.python-version }}
-    - name: Install Python package and dependencies
-      run: |
-        _pip_install="pip install --progress-bar off"
-        echo '::group::Output of "pip install" commands'
-        $_pip_install --upgrade pip wheel setuptools
-        $_pip_install -r requirements-dev.txt
-        echo '::endgroup::'
-        echo '::group::Display installed packages'
-        conda list
-        pip list
-        pip show idaes-pse
-        echo '::endgroup::'
-        echo '::group::Output of "idaes get-extensions" command'
-        idaes get-extensions --verbose
-        echo '::endgroup::'
     - name: Run nbcheck (execution)
-      uses: gmlc-dispatches/nbcheck@0.1.12
-      with:
-        setup-python: 'false'
-        type: execution
-        pytest-keywords: ipynb
+      run:
+        pytest --nbcheck=exec --cell-timeout=900

--- a/.github/workflows/notebooks-checks.yml
+++ b/.github/workflows/notebooks-checks.yml
@@ -58,4 +58,4 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Run nbcheck (execution)
       run:
-        pytest --nbcheck=exec --cell-timeout=900
+        pytest --nbcheck=exec --cell-timeout=600

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 # pytest.ini
 [pytest]
-testpaths = dispatches
+addopts =
+    --pyargs dispatches
 log_file = pytest.log
 log_file_date_format = %Y-%m-%dT%H:%M:%S
 log_file_format = %(asctime)s %(levelname)-7s <%(filename)s:%(lineno)d> %(message)s

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ addheader
 dispatches-sample-data==22.9.19
 nbval
 nbsphinx
+git+https://github.com/gmlc-dispatches/nbcheck@0.2.1
 
 --editable .


### PR DESCRIPTION
## Addresses issue: #181

## Summary/Motivation:

- The [nbcheck](https://github.com/gmlc-dispatches/nbcheck) plugin for testing Jupyter notebooks has been updated to 0.2.x with a streamlined structure and new features
- This PR updates the relevant GHA workflows so that the newest tagged version of `nbcheck` is used
- Originally these changes were made as part of #186, but since #178 has been resolved by #179, #184 (and therefore #186) are no longer needed

## Changes proposed in this PR:

- Add nbcheck to dev requirements
- Update `notebooks-checks.yml` GHA workflow file to use features from nbcheck 0.2.x
- Update default flags in `pytest.ini` 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md and COPYRIGHT.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
